### PR TITLE
Refactor: localize UI strings

### DIFF
--- a/android/app/src/main/java/dev/zebrafinch/chocorec/ui/exercises/ExercisesScreen.kt
+++ b/android/app/src/main/java/dev/zebrafinch/chocorec/ui/exercises/ExercisesScreen.kt
@@ -174,13 +174,13 @@ private fun ExerciseRow(
                 IconButton(onClick = onMoveUp, enabled = canMoveUp) {
                     Icon(
                         imageVector = Icons.Filled.KeyboardArrowUp,
-                        contentDescription = "上に移動"
+                        contentDescription = stringResource(R.string.exercises_move_up)
                     )
                 }
                 IconButton(onClick = onMoveDown, enabled = canMoveDown) {
                     Icon(
                         imageVector = Icons.Filled.KeyboardArrowDown,
-                        contentDescription = "下に移動"
+                        contentDescription = stringResource(R.string.exercises_move_down)
                     )
                 }
             }

--- a/android/app/src/main/java/dev/zebrafinch/chocorec/ui/history/HistoryViewModel.kt
+++ b/android/app/src/main/java/dev/zebrafinch/chocorec/ui/history/HistoryViewModel.kt
@@ -13,7 +13,8 @@ import kotlinx.coroutines.launch
 
 class HistoryViewModel(
     private val trainingRepository: TrainingRepository,
-    private val exerciseRepository: ExerciseRepository
+    private val exerciseRepository: ExerciseRepository,
+    private val csvHeaders: List<String>
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(HistoryUiState())
     val uiState: StateFlow<HistoryUiState> = _uiState
@@ -60,16 +61,6 @@ class HistoryViewModel(
 
     suspend fun buildCsvContent(): String {
         val records = trainingRepository.getAllRecords()
-        val headers = listOf(
-            "日付",
-            "種目",
-            "回数",
-            "セット数",
-            "重さ(kg)",
-            "作成日時",
-            "更新日時"
-        )
-
         val rows = records.map { record ->
             listOf(
                 CsvUtil.escape(record.date),
@@ -83,7 +74,7 @@ class HistoryViewModel(
         }
 
         return buildString {
-            append(headers.joinToString(","))
+            append(csvHeaders.joinToString(","))
             append("\n")
             rows.forEach { row ->
                 append(row)

--- a/android/app/src/main/java/dev/zebrafinch/chocorec/ui/history/HistoryViewModelFactory.kt
+++ b/android/app/src/main/java/dev/zebrafinch/chocorec/ui/history/HistoryViewModelFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import dev.zebrafinch.chocorec.di.RepositoryProvider
+import dev.zebrafinch.chocorec.R
 
 class HistoryViewModelFactory(
     private val context: Context
@@ -12,8 +13,17 @@ class HistoryViewModelFactory(
         if (modelClass.isAssignableFrom(HistoryViewModel::class.java)) {
             val trainingRepo = RepositoryProvider.trainingRepository(context)
             val exerciseRepo = RepositoryProvider.exerciseRepository(context)
+            val headers = listOf(
+                context.getString(R.string.csv_header_date),
+                context.getString(R.string.csv_header_exercise),
+                context.getString(R.string.csv_header_count),
+                context.getString(R.string.csv_header_sets),
+                context.getString(R.string.csv_header_weight),
+                context.getString(R.string.csv_header_created_at),
+                context.getString(R.string.csv_header_updated_at)
+            )
             @Suppress("UNCHECKED_CAST")
-            return HistoryViewModel(trainingRepo, exerciseRepo) as T
+            return HistoryViewModel(trainingRepo, exerciseRepo, headers) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/android/app/src/main/java/dev/zebrafinch/chocorec/ui/main/MainViewModel.kt
+++ b/android/app/src/main/java/dev/zebrafinch/chocorec/ui/main/MainViewModel.kt
@@ -18,7 +18,8 @@ import kotlinx.coroutines.launch
 
 class MainViewModel(
     private val trainingRepository: TrainingRepository,
-    private val exerciseRepository: ExerciseRepository
+    private val exerciseRepository: ExerciseRepository,
+    private val noneLabel: String
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(MainUiState())
     val uiState: StateFlow<MainUiState> = _uiState
@@ -171,7 +172,7 @@ class MainViewModel(
                     it.copy(
                         selectedCount = latest.count,
                         selectedSets = latest.sets,
-                        selectedWeight = latest.weight?.toInt()?.toString() ?: "なし"
+                        selectedWeight = latest.weight?.toInt()?.toString() ?: noneLabel
                     )
                 }
             }
@@ -199,7 +200,7 @@ class MainViewModel(
 
     private fun weightOptions(): List<String> {
         val weights = (5..100 step 5).map { it.toString() }
-        return listOf("なし") + weights
+        return listOf(noneLabel) + weights
     }
 
     private fun parseWeight(value: String): Float? {

--- a/android/app/src/main/java/dev/zebrafinch/chocorec/ui/main/MainViewModelFactory.kt
+++ b/android/app/src/main/java/dev/zebrafinch/chocorec/ui/main/MainViewModelFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import dev.zebrafinch.chocorec.di.RepositoryProvider
+import dev.zebrafinch.chocorec.R
 
 class MainViewModelFactory(
     private val context: Context
@@ -12,8 +13,9 @@ class MainViewModelFactory(
         if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
             val trainingRepo = RepositoryProvider.trainingRepository(context)
             val exerciseRepo = RepositoryProvider.exerciseRepository(context)
+            val noneLabel = context.getString(R.string.label_none)
             @Suppress("UNCHECKED_CAST")
-            return MainViewModel(trainingRepo, exerciseRepo) as T
+            return MainViewModel(trainingRepo, exerciseRepo, noneLabel) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/android/app/src/main/java/dev/zebrafinch/chocorec/util/DateTimeUtil.kt
+++ b/android/app/src/main/java/dev/zebrafinch/chocorec/util/DateTimeUtil.kt
@@ -1,6 +1,5 @@
 package dev.zebrafinch.chocorec.util
 
-import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -17,29 +16,6 @@ object DateTimeUtil {
 
     fun nowIso(): String {
         return LocalDateTime.now().format(dateTimeFormatter)
-    }
-
-    fun formatHistoryDate(dateStr: String): String {
-        val date = LocalDate.parse(dateStr, dateFormatter)
-        val today = LocalDate.now()
-        val yesterday = today.minusDays(1)
-
-        return when (date) {
-            today -> "今日"
-            yesterday -> "昨日"
-            else -> {
-                val weekday = when (date.dayOfWeek) {
-                    DayOfWeek.MONDAY -> "月"
-                    DayOfWeek.TUESDAY -> "火"
-                    DayOfWeek.WEDNESDAY -> "水"
-                    DayOfWeek.THURSDAY -> "木"
-                    DayOfWeek.FRIDAY -> "金"
-                    DayOfWeek.SATURDAY -> "土"
-                    DayOfWeek.SUNDAY -> "日"
-                }
-                "${date.monthValue}月${date.dayOfMonth}日($weekday)"
-            }
-        }
     }
 
     fun formatPickerDate(dateStr: String): String {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,10 +11,23 @@
     <string name="label_count">回数</string>
     <string name="label_sets">セット</string>
     <string name="label_weight">重さ(kg)</string>
+    <string name="label_none">なし</string>
     <string name="button_record">記録する</string>
     <string name="placeholder_chart">表示する記録がありません</string>
     <string name="history_title">履歴</string>
     <string name="history_empty">記録がありません</string>
+    <string name="history_today">今日</string>
+    <string name="history_yesterday">昨日</string>
+    <string name="history_weekday_mon">月</string>
+    <string name="history_weekday_tue">火</string>
+    <string name="history_weekday_wed">水</string>
+    <string name="history_weekday_thu">木</string>
+    <string name="history_weekday_fri">金</string>
+    <string name="history_weekday_sat">土</string>
+    <string name="history_weekday_sun">日</string>
+    <string name="history_date_format">%1$d月%2$d日(%3$s)</string>
+    <string name="history_weight_suffix"> @ %1$skg</string>
+    <string name="history_record_summary">%1$d 回 x %2$d セット%3$s</string>
     <string name="action_csv_save">CSV保存</string>
     <string name="action_edit">編集</string>
     <string name="action_back">戻る</string>
@@ -23,6 +36,8 @@
     <string name="action_cancel">キャンセル</string>
     <string name="exercises_title">種目管理</string>
     <string name="exercises_empty">種目がありません</string>
+    <string name="exercises_move_up">上に移動</string>
+    <string name="exercises_move_down">下に移動</string>
     <string name="action_add">追加</string>
     <string name="label_name">種目名</string>
     <string name="label_color">色</string>
@@ -39,4 +54,11 @@
     <string name="version_label">アプリのバージョン</string>
     <string name="delete_title">削除の確認</string>
     <string name="delete_confirm">この種目を削除しますか？</string>
+    <string name="csv_header_date">日付</string>
+    <string name="csv_header_exercise">種目</string>
+    <string name="csv_header_count">回数</string>
+    <string name="csv_header_sets">セット数</string>
+    <string name="csv_header_weight">重さ(kg)</string>
+    <string name="csv_header_created_at">作成日時</string>
+    <string name="csv_header_updated_at">更新日時</string>
 </resources>


### PR DESCRIPTION
## Summary
- Move hardcoded JP UI text into strings.xml (history labels, record summary, CSV headers, none label)
- Inject localized CSV headers and none label via ViewModel factories
- Replace history date formatting with localized formatting in HistoryScreen

## Testing
- Manual (user): history date/summary/weights, CSV headers, exercises move labels